### PR TITLE
create workflow for image builder

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,31 @@
+name: cleanup caches by a branch
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,73 @@
+name: Build and Push Docker Image report api service
+
+on:
+  push:
+    branches:
+      - main  # Trigger workflow on push to the main branch
+  pull_request:
+    branches:
+      - main  # Optional: Run the workflow on PRs targeting main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  BUILDER_NAME: mybuilder
+  BUILD_PLATFORMS_TARGET: ${{ vars.BUILD_PLATFORMS_TARGET }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  build-image:
+    runs-on: image-builder
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        if: github.event_name != 'pull_request'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+            prefix=
+            suffix=
+
+      - name: Expose GitHub Runtime
+        if: github.event_name != 'pull_request'
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Build
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS_TARGET }}
+          push: ${{ github.event_name != 'pull_request' }}
+          builder: ${{ env.BUILDER_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate cache cleanup and Docker image building for the repository. The most important changes include the addition of a workflow to clean up caches when a pull request is closed and another workflow to build and push Docker images upon pushes and pull requests to the main branch.

New GitHub Actions workflows:

* [`.github/workflows/cleanup-caches.yml`](diffhunk://#diff-8945a3361778b570d0b11fc891f119ef85ed7959a3f49cac6c914a76626bc36eR1-R31): Added a workflow to clean up caches by branch when a pull request is closed. This workflow fetches and deletes cache keys associated with the pull request.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R1-R73): Added a workflow to build and push Docker images for the report API service. This workflow triggers on pushes and pull requests to the main branch, logs in to the GitHub Container Registry, builds the Docker image, and optionally generates an artifact attestation.