### PR TITLE
fix: ensure migration command exits on failure in startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
-php artisan migrate --force
-exec /usr/bin/supervisord -c /etc/supervisord.conf
 
+
+php artisan migrate --force || exit $?
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
This pull request includes a small but important change to the `startup.sh` script. The change ensures that if the `php artisan migrate --force` command fails, the script will exit with the appropriate status code.

* [`startup.sh`](diffhunk://#diff-fd9da3f9dec4caa8673d458984c592d21a5880ae71051e254c5ceba876b1ede9L2-R6): Added an exit status check to the `php artisan migrate --force` command to ensure the script exits if the migration fails.