### PR TITLE
feat: configure Chromium settings in app config for report generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,12 +14,10 @@ app/storage/
 # Laravel 5 & Lumen specific
 public/storage
 public/hot
-public/build
 
 # Laravel 5 & Lumen specific with changed public path
 public_html/storage
 public_html/hot
-public_html/build
 
 storage/*.key
 .env

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -21,6 +21,7 @@ use Spatie\Browsershot\Browsershot;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\URL;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
 
 class ReportController extends Controller
 {
@@ -456,11 +457,12 @@ class ReportController extends Controller
         $pdfPath = storage_path('app/reports/report_' . $id . '.pdf');
         $url = URL::signedRoute('reports.view', ['id' => $id]);
         // $headerHtml = view('reports.alert_report_header')->render();
-        $chromiumIpAddress = env('CHROMIUM_IP_ADDRESS');
-        $chromiumPort = env('CHROMIUM_PORT');
 
         Browsershot::url($url)
-            ->setRemoteInstance($chromiumIpAddress, $chromiumPort)
+            ->setRemoteInstance(
+                Config::get('app.chromium.address'),
+                Config::get('app.chromium.port'),
+            )
             ->waitUntilNetworkIdle()
             ->format('A4')
             ->showBackground()
@@ -533,4 +535,3 @@ class ReportController extends Controller
         throw new \InvalidArgumentException("IP address is required");
     }
 }
-

--- a/config/app.php
+++ b/config/app.php
@@ -122,6 +122,11 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
-    
+
+
+    'chromium' => [
+        'address' => env('CHROMIUM_IP_ADDRESS', "localhost"),
+        'port' => env('CHROMIUM_PORT', 9222),
+    ],
 
 ];


### PR DESCRIPTION
This pull request includes changes to the `ReportController` and configuration files to improve the management of the Chromium instance settings.

Configuration updates:

* [`config/app.php`](diffhunk://#diff-950397cc5ef29707b54d0c774bd94af85836bab1a27f2f86533d832d25caf224R127-R131): Added a new configuration section for Chromium settings, specifying the address and port with default values.

Code updates in `ReportController`:

* [`app/Http/Controllers/ReportController.php`](diffhunk://#diff-2ea542f80be40b880eb0dd8df664e236dec81f0e0a798feb214f98602ce860f0R24): Added the `Config` facade to the imports.
* [`app/Http/Controllers/ReportController.php`](diffhunk://#diff-2ea542f80be40b880eb0dd8df664e236dec81f0e0a798feb214f98602ce860f0L459-R465): Updated the `downloadReport` method to use the new Chromium settings from the configuration file instead of environment variables.
* [`app/Http/Controllers/ReportController.php`](diffhunk://#diff-2ea542f80be40b880eb0dd8df664e236dec81f0e0a798feb214f98602ce860f0L536): Removed an unnecessary blank line at the end of the `createOrUpdateIdentity` method.